### PR TITLE
Dev 118714 implement functionality to exclude metadata from lm logs logstash plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ output {
 | keep_timestamp | If false, LM Logs will use the ingestion timestamp as the event timestamp | true |
 | timestamp_is_key  | If true, LM Logs will use a specified key as the event timestamp | false |
 | timestamp_key | If timestamp_is_key is set, LM Logs will use this key in the event as the timestamp | "logtimestamp"  |
+| include_metadata  | If false, the metadata fields will not be sent to LM Logs  | true |
 
 See the [source code](lib/logstash/outputs/lmlogs.rb) for the full list of options
 

--- a/lib/logstash/outputs/lmlogs.rb
+++ b/lib/logstash/outputs/lmlogs.rb
@@ -93,12 +93,11 @@ class LogStash::Outputs::LMLogs < LogStash::Outputs::Base
   # Username to use for HTTP auth.
   config :access_id, :validate => :string, :required => true
 
+  # Include/Exclude metadata from sending to LM Logs
   config :include_metadata, :validate => :boolean, :default => true
 
   # Password to use for HTTP auth
   config :access_key, :validate => :password, :required => true
-
-  config :exclude_metadata, :validate => :array, :default => []
 
   @@MAX_PAYLOAD_SIZE = 8*1024*1024
 

--- a/logstash-output-lmlogs.gemspec
+++ b/logstash-output-lmlogs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-lmlogs'
-  s.version         = '1.1.0'
+  s.version         = '1.2.0'
   s.licenses = ['Apache-2.0']
   s.summary = "Logstash output plugin for LM Logs"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adding flag 'include_metadata' with default value true to include all the metadata.
To exclude any specific metadata user can use https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html#plugins-filters-mutate-remove_field
Because the event can consist of nested objects and it will require extra processing from our plugin to exclude such objects making it heavy to use