### PR TITLE
Adding restriction/validation on the allowed domains for LM portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ output {
 }
 ```
 You would need either `access_id` and `access_id` both or `bearer_token` for authentication with Logicmonitor. 
-The portal_domain is the domain of your LM portal. If not set the default is set to `logicmonitor.com`. Eg if your LM portal URL is `https://test.domain.com`, portal_name should be set to `test` and portal_domain to `domain.com`
+The portal_domain is the domain of your LM portal. If not set the default is set to `logicmonitor.com`. Eg if your LM portal URL is `https://test.lmgov.us`, portal_name should be set to `test` and portal_domain to `lmgov.us`
+The allowed values for portal_domain are ["logicmonitor.com", "lmgov.us", "qa-lmgov.us"]
 
 
 

--- a/lib/logstash/outputs/lmlogs.rb
+++ b/lib/logstash/outputs/lmlogs.rb
@@ -115,6 +115,8 @@ class LogStash::Outputs::LMLogs < LogStash::Outputs::Base
   # For developer debugging.
   @@CONSOLE_LOGS = false
 
+  ALLOWED_DOMAINS = ["logicmonitor.com", "lmgov.us", "qa-lmgov.us"]
+
   public
   def register
     @total = 0
@@ -129,6 +131,11 @@ class LogStash::Outputs::LMLogs < LogStash::Outputs::Base
     if @portal_domain.nil? || @portal_domain.strip.empty?
       @portal_domain = "logicmonitor.com"
     end
+
+     unless ALLOWED_DOMAINS.include?(@portal_domain)
+          raise LogStash::ConfigurationError, "Invalid portal_domain: #{@portal_domain}. Allowed values are: #{ALLOWED_DOMAINS.join(', ')}"
+     end
+     log_debug("Setting LM portal domain ", :portal_domain => portal_domain)
 
     @final_metadata_keys = Hash.new
     if @include_metadata_keys.any?

--- a/lib/logstash/outputs/version.rb
+++ b/lib/logstash/outputs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LmLogsLogstashPlugin
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end


### PR DESCRIPTION
Restricting/validating the value of portal_domain to be in the list of allowed_domains : ["logicmonitor.com", "lmgov.us", "qa-lmgov.us"]